### PR TITLE
Added Get-AzureMigrateAssessmentsDetailed() extended New-AzureMigrateAssessment()

### DIFF
--- a/AzMigrate.psm1
+++ b/AzMigrate.psm1
@@ -285,6 +285,53 @@ function Get-AzureMigrateAssessments {
 
 <#
 .SYNOPSIS
+Downloads the excel export of a specified assessment.
+.DESCRIPTION
+The Get-AzureMigrateAssessmentExport cmdlet downloads excel export of a specified assessment.
+.PARAMETER SubscriptionID
+Specifies the Azure subscription to query.
+.PARAMETER ResourceGroup
+Specifies the resoruce group containing the Azure Migrate project.
+.PARAMETER Project
+Specifies the Azure Migrate project to query.
+.PARAMETER GroupName
+Specifies the group name in the project.
+.PARAMETER AssessmentName
+Specifies the assessment name in the group.
+.EXAMPLE
+Download excel report for the specified assessment.
+PS C:\>Get-AzureMigrateAssessmentExport -Token $token -Project xx -SubscriptionID xx -ResourceGroup xx -GroupName "myGroup" -AssessmentName "myFirstAssessment"
+
+#>
+function Get-AzureMigrateAssessmentExport {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $true)][string]$Token,
+        [Parameter(Mandatory = $true)][string]$SubscriptionID,
+        [Parameter(Mandatory = $true)][string]$ResourceGroup,
+        [Parameter(Mandatory = $true)][string]$Project,
+        [Parameter(Mandatory = $true)][string]$GroupName,
+        [Parameter(Mandatory = $true)][string]$AssessmentName,
+        [Parameter(Mandatory = $true)][string]$Filename
+    )
+
+    #$obj = @()
+    $url = "https://management.azure.com/subscriptions/{0}/resourceGroups/{1}/providers/Microsoft.Migrate/assessmentprojects/{2}/groups/{3}/assessments/{4}/downloadUrl?api-version=2019-05-01" -f $SubscriptionID, $ResourceGroup, $Project, $GroupName, $AssessmentName
+
+    $headers = New-Object 'System.Collections.Generic.Dictionary[[string],[string]]'
+    $headers.Add("Authorization", "Bearer $Token")
+
+    $response = Invoke-RestMethod -Uri $url -Headers $headers -ContentType "application/json" -Method "POST" #-Debug -Verbose
+
+    $downloadresponse = Invoke-WebRequest -uri $response.assessmentReportUrl -OutFile $Filename -PassThru
+
+    #$obj += $response.Substring(1) | ConvertFrom-Json
+    #return (_formatResult -obj $obj -type "AzureMigrateProject")
+    return $downloadresponse.StatusCode
+}
+
+<#
+.SYNOPSIS
 Returns details of assessments, including costs from the specified Azure Migrate project.
 .DESCRIPTION
 The Get-AzureMigrateAssessmentsDetailed cmdlet returns details of assessments from the specified Azure Migrate project.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ $AzMigGroups | Select-Object name, {$_.properties.machinecount}
 # Create assessments for the new group using our assessment templates
 $assessment01 = New-AzureMigrateAssessment -Token $token -SubscriptionID $subscriptionid -ResourceGroup $rg -Project $projects[0].name -AssessmentName "Assessment01" -Group $updatedGroup.name -AssessmentProperties .\SampleAssessmentProperties01.json
 $assessment02 = New-AzureMigrateAssessment -Token $token -SubscriptionID $subscriptionid -ResourceGroup $rg -Project $projects[0].name -AssessmentName "Assessment02" -Group $updatedGroup.name -AssessmentProperties .\SampleAssessmentProperties02.json
+$assessment03 = New-AzureMigrateAssessment -Token $token -SubscriptionID $subscriptionid -ResourceGroup $rg -Project $projects[0].name -AssessmentName "Assessment03" -Group $updatedGroup.name -AssessmentPropertiesString "{assessment properties as json string}"
 
 # Get a summary of assessments for the project
 $assessments = Get-AzureMigrateAssessments -Token $token -SubscriptionID $subscriptionid -ResourceGroup $rg -Project $projects[0].name
@@ -95,6 +96,10 @@ $assessments |Select-Object name, @{Name='Type';Expression={$_.properties.sizing
 $assessedmachines = Get-AzureMigrateAssessedMachine -Token $token -SubscriptionID $subscriptionid -ResourceGroup $rg -Project $projects[0].name -GroupName $AzMigGroups[5].name -AssessmentName $assessments[10].name
 # Summarise details of assessed machines
 $assessedmachines | Select-Object {$_.properties.displayname}, {$_.properties.operatingsystemname}, {$_.properties.suitability}, {$_.properties.recommendedSize}
+
+# Alternative solution: Get all assessments including details for the project
+$Assessments = Get-AzureMigrateAssessmentsDetailed -Token $token -SubscriptionID $subscriptionid -ResourceGroup $rg -Project $projects[0].name   
+
 
 ```
 


### PR DESCRIPTION
Added AssessmentPropertiesString-Parameter to New-AzureMigrateAssessment() to pass a json string containing the assessment properties instead of a file. AssessmentProperties still works for downward compatibility.

Added a new Function Get-AzureMigrateAssessmentsDetailed() to return detailed / all available information from created assessments.